### PR TITLE
[FE] task 카드 추가 기능 #7

### DIFF
--- a/client/src/components/Modal/index.js
+++ b/client/src/components/Modal/index.js
@@ -21,9 +21,9 @@ export default class Modal {
     return `
       <div class="modal">
         <h3 class="modal__message">${message}</h3>
-        <div class="modal__utils">
-          <button class="modal__btn modal__btn--cancel">취소</button>
-          <button class="modal__btn modal__btn--confirm">삭제</button>
+        <div class="util__btns">
+          <button class="util__btn--big util__btn--cancel">취소</button>
+          <button class="util__btn--big util__btn--confirm">삭제</button>
         </div>
       </div>
     `;

--- a/client/src/components/Modal/index.scss
+++ b/client/src/components/Modal/index.scss
@@ -21,27 +21,4 @@
     margin-bottom: 1.5rem;
     font-size: 1.125rem;
   }
-
-  &__utils {
-    display: flex;
-    justify-content: flex-end;
-    gap: 0.5rem;
-  }
-
-  &__btn {
-    width: 8.375rem;
-    height: 2.5rem;
-    font-size: 0.875rem;
-    border-radius: 0.375rem;
-
-    &--cancel {
-      background: $grey5;
-      color: $grey3;
-    }
-
-    &--confirm {
-      background: $blue;
-      color: $white;
-    }
-  }
 }

--- a/client/src/components/TaskBoard/TaskCardList/EditingTaskCard/index.js
+++ b/client/src/components/TaskBoard/TaskCardList/EditingTaskCard/index.js
@@ -24,21 +24,21 @@ export default class EditingTaskCard {
   #getEditingTaskDetailTemplate(details) {
     const originalDetailContent = details ? details.join('\n') : '';
     return `
-        <textarea placeholder="내용을 입력하세요" class="taskCard__detail--editing">
-            ${originalDetailContent}
-        </textarea>
+        <textarea placeholder="내용을 입력하세요" class="taskCard__detail--editing">${originalDetailContent}</textarea>
     `;
   }
 
   #getInnerTemplate() {
     const { title, details } = this.originalCardData;
     return `
-            <input type = "text" class="taskCard__title editing" placeholder="제목을 입력하세요">${title}</h3>
-            ${this.#getEditingTaskDetailTemplate(details)}
-            <div class="util__btns">
-                <button class="util__btn--big util__btn--cancel">취소</button>
-                <button class="util__btn--big util__btn--confirm">등록</button>
-            </div>
-        `;
+      <input type = "text" class="taskCard__title editing" placeholder="제목을 입력하세요" value=${
+        title ? title : ''
+      }>
+      ${this.#getEditingTaskDetailTemplate(details)}
+      <div class="util__btns">
+          <button class="util__btn--big util__btn--cancel">취소</button>
+          <button class="util__btn--big util__btn--confirm">등록</button>
+      </div>
+    `;
   }
 }

--- a/client/src/components/TaskBoard/TaskCardList/EditingTaskCard/index.js
+++ b/client/src/components/TaskBoard/TaskCardList/EditingTaskCard/index.js
@@ -1,0 +1,40 @@
+export default class EditingTaskCard {
+  #$editingTaskCard;
+
+  constructor($parent, originalCardData = {}) {
+    this.$parent = $parent;
+    this.originalCardData = originalCardData;
+    this.#makeEditingTaskCardElement();
+  }
+
+  render() {
+    this.#$editingTaskCard.innerHTML = this.#getInnerTemplate();
+    this.$parent.append(this.#$editingTaskCard);
+  }
+
+  #makeEditingTaskCardElement() {
+    this.#$editingTaskCard = document.createElement('div');
+    this.#$editingTaskCard.className = 'taskCard editing';
+  }
+
+  #getEditingTaskDetailTemplate(details) {
+    const originalDetailContent = details ? details.join('\n') : '';
+    return `
+        <textarea placeholder="내용을 입력하세요" class="taskCard__detail--editing">
+            ${originalDetailContent}
+        </textarea>
+    `;
+  }
+
+  #getInnerTemplate() {
+    const { title, details } = this.originalCardData;
+    return `
+            <input type = "text" class="taskCard__title editing" placeholder="제목을 입력하세요">${title}</h3>
+            ${this.#getEditingTaskDetailTemplate(details)}
+            <div class="util__btns">
+                <button class="util__btn--big util__btn--cancel">취소</button>
+                <button class="util__btn--big util__btn--confirm">등록</button>
+            </div>
+        `;
+  }
+}

--- a/client/src/components/TaskBoard/TaskCardList/EditingTaskCard/index.js
+++ b/client/src/components/TaskBoard/TaskCardList/EditingTaskCard/index.js
@@ -7,14 +7,18 @@ export default class EditingTaskCard {
     this.#makeEditingTaskCardElement();
   }
 
-  render() {
-    this.#$editingTaskCard.innerHTML = this.#getInnerTemplate();
-    this.$parent.append(this.#$editingTaskCard);
-  }
-
   #makeEditingTaskCardElement() {
     this.#$editingTaskCard = document.createElement('div');
     this.#$editingTaskCard.className = 'taskCard editing';
+  }
+
+  render() {
+    this.#fillTaskCardElement();
+    this.$parent.append(this.#$editingTaskCard);
+  }
+
+  #fillTaskCardElement() {
+    this.#$editingTaskCard.innerHTML = this.#getInnerTemplate();
   }
 
   #getEditingTaskDetailTemplate(details) {

--- a/client/src/components/TaskBoard/TaskCardList/TaskCard/index.js
+++ b/client/src/components/TaskBoard/TaskCardList/TaskCard/index.js
@@ -6,15 +6,15 @@ export default class TaskCard {
   constructor($parent, cardData) {
     this.$parent = $parent;
     this.cardData = cardData;
-    this.#makeTaskCard();
+    this.#makeTaskCardElement();
   }
 
   render() {
-    this.#$taskCard.innerHTML = this.#getInnerTemplate();
     this.$parent.append(this.#$taskCard);
+    this.#$taskCard.innerHTML = this.#getInnerTemplate();
   }
 
-  #makeTaskCard() {
+  #makeTaskCardElement() {
     this.#$taskCard = document.createElement('div');
     this.#$taskCard.className = 'taskCard';
   }

--- a/client/src/components/TaskBoard/TaskCardList/TaskCard/index.js
+++ b/client/src/components/TaskBoard/TaskCardList/TaskCard/index.js
@@ -9,14 +9,18 @@ export default class TaskCard {
     this.#makeTaskCardElement();
   }
 
-  render() {
-    this.$parent.append(this.#$taskCard);
-    this.#$taskCard.innerHTML = this.#getInnerTemplate();
-  }
-
   #makeTaskCardElement() {
     this.#$taskCard = document.createElement('div');
     this.#$taskCard.className = 'taskCard';
+  }
+
+  render() {
+    this.#fillTaskCardElement();
+    this.$parent.append(this.#$taskCard);
+  }
+
+  #fillTaskCardElement() {
+    this.#$taskCard.innerHTML = this.#getInnerTemplate();
   }
 
   #getInnerTemplate() {

--- a/client/src/components/TaskBoard/TaskCardList/TaskCard/index.js
+++ b/client/src/components/TaskBoard/TaskCardList/TaskCard/index.js
@@ -6,17 +6,17 @@ export default class TaskCard {
   constructor($parent, cardData) {
     this.$parent = $parent;
     this.cardData = cardData;
-    this.#makeDOM();
+    this.#makeTaskCard();
   }
 
   render() {
     this.#$taskCard.innerHTML = this.#getInnerTemplate();
+    this.$parent.append(this.#$taskCard);
   }
 
-  #makeDOM() {
+  #makeTaskCard() {
     this.#$taskCard = document.createElement('div');
     this.#$taskCard.className = 'taskCard';
-    this.$parent.append(this.#$taskCard);
   }
 
   #getInnerTemplate() {

--- a/client/src/components/TaskBoard/TaskCardList/TaskCard/index.js
+++ b/client/src/components/TaskBoard/TaskCardList/TaskCard/index.js
@@ -7,16 +7,15 @@ export default class TaskCard {
     this.$parent = $parent;
     this.cardData = cardData;
     this.#makeDOM();
-    this.#render();
+  }
+
+  render() {
+    this.#$taskCard.innerHTML = this.#getInnerTemplate();
   }
 
   #makeDOM() {
     this.#$taskCard = document.createElement('div');
     this.#$taskCard.className = 'taskCard';
-  }
-
-  #render() {
-    this.#$taskCard.innerHTML = this.#getInnerTemplate();
     this.$parent.append(this.#$taskCard);
   }
 

--- a/client/src/components/TaskBoard/TaskCardList/index.js
+++ b/client/src/components/TaskBoard/TaskCardList/index.js
@@ -8,19 +8,20 @@ export default class TaskCardList {
   constructor($parent, cardListData) {
     this.$parent = $parent;
     this.cardListData = cardListData;
-    this.#makeDOM();
+    this.#makeTaskCardListElement();
+    this.#makeTaskCards();
   }
 
   render() {
     this.#$taskCardList.innerHTML = this.#getInnerTemplate();
     this.#mountTaskCards();
-    //this.#activate();
+    this.#activate();
+    this.$parent.append(this.#$taskCardList);
   }
 
-  #makeDOM() {
+  #makeTaskCardListElement() {
     this.#$taskCardList = document.createElement('section');
     this.#$taskCardList.className = 'taskcard-list';
-    this.$parent.append(this.#$taskCardList);
   }
 
   #getInnerTemplate() {
@@ -39,7 +40,6 @@ export default class TaskCardList {
   }
 
   #mountTaskCards() {
-    this.#makeTaskCards();
     this.#taskCards.forEach((taskCard) => taskCard.render());
   }
 
@@ -51,20 +51,20 @@ export default class TaskCardList {
     );
   }
 
-  // #activate() {
-  //   this.#activateAddBtn();
-  // }
+  #activate() {
+    this.#activateAddBtn();
+  }
 
-  // #activateAddBtn() {
-  //   const $addBtn = this.#$taskCardList.querySelector(
-  //     '.taskcard-list__add-btn'
-  //   );
-  //   $addBtn.addEventListener('click', () => this.#addNewTaskCard());
-  // }
+  #activateAddBtn() {
+    const $addBtn = this.#$taskCardList.querySelector(
+      '.taskcard-list__add-btn'
+    );
+    $addBtn.addEventListener('click', () => this.#addNewTaskCard());
+  }
 
-  // #addNewTaskCard() {
-  //   const newTaskCard = new Ed();
-  //   this.#taskCards.unshift(newTaskCard);
-  //   this.#taskCards.forEach((taskCard) => taskCard.render());
-  // }
+  #addNewTaskCard() {
+    const newTaskCard = new EditingTaskCard();
+    this.#taskCards.unshift(newTaskCard);
+    this.render();
+  }
 }

--- a/client/src/components/TaskBoard/TaskCardList/index.js
+++ b/client/src/components/TaskBoard/TaskCardList/index.js
@@ -3,23 +3,23 @@ import TaskCard from './TaskCard';
 
 export default class TaskCardList {
   #$taskCardList;
-  #taksCards;
+  #taskCards;
 
   constructor($parent, cardListData) {
     this.$parent = $parent;
     this.cardListData = cardListData;
     this.#makeDOM();
-    this.#render();
+  }
+
+  render() {
+    this.#$taskCardList.innerHTML = this.#getInnerTemplate();
     this.#mountTaskCards();
+    //this.#activate();
   }
 
   #makeDOM() {
     this.#$taskCardList = document.createElement('section');
     this.#$taskCardList.className = 'taskcard-list';
-  }
-
-  #render() {
-    this.#$taskCardList.innerHTML = this.#getInnerTemplate();
     this.$parent.append(this.#$taskCardList);
   }
 
@@ -39,9 +39,32 @@ export default class TaskCardList {
   }
 
   #mountTaskCards() {
+    this.#makeTaskCards();
+    this.#taskCards.forEach((taskCard) => taskCard.render());
+  }
+
+  #makeTaskCards() {
+    // 데이터 포맷팅 (나중에 달라질 수 있음)
     const cardDataArr = this.cardListData.tasks;
-    this.#taksCards = cardDataArr.map(
+    this.#taskCards = cardDataArr.map(
       (cardData) => new TaskCard(this.#$taskCardList, cardData)
     );
   }
+
+  // #activate() {
+  //   this.#activateAddBtn();
+  // }
+
+  // #activateAddBtn() {
+  //   const $addBtn = this.#$taskCardList.querySelector(
+  //     '.taskcard-list__add-btn'
+  //   );
+  //   $addBtn.addEventListener('click', () => this.#addNewTaskCard());
+  // }
+
+  // #addNewTaskCard() {
+  //   const newTaskCard = new Ed();
+  //   this.#taskCards.unshift(newTaskCard);
+  //   this.#taskCards.forEach((taskCard) => taskCard.render());
+  // }
 }

--- a/client/src/components/TaskBoard/TaskCardList/index.js
+++ b/client/src/components/TaskBoard/TaskCardList/index.js
@@ -13,17 +13,28 @@ export default class TaskCardList {
     this.#makeTaskCards();
   }
 
-  //render
-  render() {
-    this.#$taskCardList.innerHTML = this.#getInnerTemplate();
-    this.#mountTaskCards();
-    this.#activate();
-  }
-
   #makeTaskCardListElement() {
     this.#$taskCardList = document.createElement('section');
     this.#$taskCardList.className = 'taskcard-list';
+  }
+
+  #makeTaskCards() {
+    // 데이터 포맷팅 (나중에 달라질 수 있음)
+    const cardDataArr = this.cardListData.tasks;
+    this.#taskCards = cardDataArr.map(
+      (cardData) => new TaskCard(this.#$taskCardList, cardData)
+    );
+  }
+
+  render() {
+    this.#fillTaskCardListElement();
     this.$parent.append(this.#$taskCardList);
+  }
+
+  #fillTaskCardListElement() {
+    this.#$taskCardList.innerHTML = this.#getInnerTemplate();
+    this.#renderTaskCards();
+    this.#activate();
   }
 
   #getInnerTemplate() {
@@ -41,16 +52,8 @@ export default class TaskCardList {
     `;
   }
 
-  #mountTaskCards() {
+  #renderTaskCards() {
     this.#taskCards.forEach((taskCard) => taskCard.render());
-  }
-
-  #makeTaskCards() {
-    // 데이터 포맷팅 (나중에 달라질 수 있음)
-    const cardDataArr = this.cardListData.tasks;
-    this.#taskCards = cardDataArr.map(
-      (cardData) => new TaskCard(this.#$taskCardList, cardData)
-    );
   }
 
   #activate() {
@@ -67,6 +70,6 @@ export default class TaskCardList {
   #addNewTaskCard() {
     const newTaskCard = new EditingTaskCard(this.#$taskCardList);
     this.#taskCards.unshift(newTaskCard);
-    this.render();
+    this.#fillTaskCardListElement();
   }
 }

--- a/client/src/components/TaskBoard/TaskCardList/index.js
+++ b/client/src/components/TaskBoard/TaskCardList/index.js
@@ -1,5 +1,6 @@
 import './index.scss';
 import TaskCard from './TaskCard';
+import EditingTaskCard from './EditingTaskCard';
 
 export default class TaskCardList {
   #$taskCardList;
@@ -12,16 +13,17 @@ export default class TaskCardList {
     this.#makeTaskCards();
   }
 
+  //render
   render() {
     this.#$taskCardList.innerHTML = this.#getInnerTemplate();
     this.#mountTaskCards();
     this.#activate();
-    this.$parent.append(this.#$taskCardList);
   }
 
   #makeTaskCardListElement() {
     this.#$taskCardList = document.createElement('section');
     this.#$taskCardList.className = 'taskcard-list';
+    this.$parent.append(this.#$taskCardList);
   }
 
   #getInnerTemplate() {
@@ -63,7 +65,7 @@ export default class TaskCardList {
   }
 
   #addNewTaskCard() {
-    const newTaskCard = new EditingTaskCard();
+    const newTaskCard = new EditingTaskCard(this.#$taskCardList);
     this.#taskCards.unshift(newTaskCard);
     this.render();
   }

--- a/client/src/components/TaskBoard/index.js
+++ b/client/src/components/TaskBoard/index.js
@@ -7,17 +7,22 @@ export default class TaskBoard {
 
   constructor($parent) {
     this.$parent = $parent;
-    this.#makeDOM();
+    this.#makeTaskBoardElement();
+    this.#makeTaskLists();
+  }
+
+  #makeTaskBoardElement() {
+    this.#$taskBoard = document.createElement('section');
+    this.#$taskBoard.className = 'task-board';
   }
 
   render() {
-    this.#mountTaskLists();
+    this.#renderTaskLists();
+    this.$parent.append(this.#$taskBoard);
   }
 
-  #makeDOM() {
-    this.#$taskBoard = document.createElement('section');
-    this.#$taskBoard.className = 'task-board';
-    this.$parent.append(this.#$taskBoard);
+  #renderTaskLists() {
+    this.#taskCardLists.forEach((taskCardList) => taskCardList.render());
   }
 
   #makeTaskLists() {
@@ -25,11 +30,6 @@ export default class TaskBoard {
     this.#taskCardLists = dummyDatas.map(
       (cardListData) => new TaskCardList(this.#$taskBoard, cardListData)
     );
-  }
-
-  #mountTaskLists() {
-    this.#makeTaskLists();
-    this.#taskCardLists.forEach((taskCardList) => taskCardList.render());
   }
 }
 

--- a/client/src/components/TaskBoard/index.js
+++ b/client/src/components/TaskBoard/index.js
@@ -8,24 +8,28 @@ export default class TaskBoard {
   constructor($parent) {
     this.$parent = $parent;
     this.#makeDOM();
-    this.#render();
+  }
+
+  render() {
     this.#mountTaskLists();
   }
 
   #makeDOM() {
     this.#$taskBoard = document.createElement('section');
     this.#$taskBoard.className = 'task-board';
-  }
-
-  #render() {
     this.$parent.append(this.#$taskBoard);
   }
 
-  #mountTaskLists() {
+  #makeTaskLists() {
     // Todo: 실제로는 data를 API 요청으로 받아와야 함
     this.#taskCardLists = dummyDatas.map(
       (cardListData) => new TaskCardList(this.#$taskBoard, cardListData)
     );
+  }
+
+  #mountTaskLists() {
+    this.#makeTaskLists();
+    this.#taskCardLists.forEach((taskCardList) => taskCardList.render());
   }
 }
 

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -5,7 +5,9 @@ import TaskBoard from '@/components/TaskBoard';
 function main() {
   const $app = document.querySelector('#app');
   new Header($app);
-  new TaskBoard($app);
+  const taskBoard = new TaskBoard($app);
+
+  taskBoard.render();
 }
 
 main();

--- a/client/src/index.scss
+++ b/client/src/index.scss
@@ -6,15 +6,40 @@ body {
   padding: 0rem 5rem;
 }
 
-.util__btn {
-  width: 1.5rem;
-  height: 1.5rem;
-
-  &--add {
-    background: url(@imgs/plus.png) no-repeat center;
+.util {
+  &__btns {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
   }
 
-  &--delete {
-    background: url(@imgs/delete.png) no-repeat center;
+  &__btn {
+    width: 1.5rem;
+    height: 1.5rem;
+
+    &--big {
+      width: 8.375rem;
+      height: 2.5rem;
+      font-size: 0.875rem;
+      border-radius: 0.375rem;
+    }
+
+    &--add {
+      background: url(@imgs/plus.png) no-repeat center;
+    }
+
+    &--delete {
+      background: url(@imgs/delete.png) no-repeat center;
+    }
+
+    &--cancel {
+      background: $grey5;
+      color: $grey3;
+    }
+
+    &--confirm {
+      background: $blue;
+      color: $white;
+    }
   }
 }

--- a/client/src/style/reset.scss
+++ b/client/src/style/reset.scss
@@ -69,3 +69,8 @@ input {
 input:focus {
   outline: none;
 }
+
+textarea {
+  border: none;
+  resize: none;
+}


### PR DESCRIPTION
 - 함께, 페어 프로그래밍을 진행하였습니다.
 - render가 기존에는 private로 되어있었는데, 부모에서 자식을 re-render해야되는 상황이 발생했기 때문에 render을 public으로 재 지정을 해줬습니다.
 - render에 innerHTML과 부모.append가 한 과정에 존재했는데, 업데이트 시에는 부모.append를 해주면 안되어서 fill함수를 추가하여 innerHTML 부분을 함수에 넣었습니다. 렌더링 시에는 render함수를 실행하고, 내부에 추가/삭제등의 update가 발생할 때는 fill함수를 실행합니다.
 - EditingCardComponent를 구현했습니다. 현재는, 화면에 렌더링 되는 정도로 구현완료 했습니다.

추후 할 것
 - EditingCard에서 CardList에 새로운 Card를 추가완료하는 과정을 거칠때 상당히 부모를 거슬러 올라가야 되는 상황이 발생할 것이기 때문에, 이벤트들을 controller에 넣어 정리할 예정입니다.