### PR TITLE
[FE] 수정 중인 카드 취소시 카드 롤백 기능구현 #11

### DIFF
--- a/client/src/components/TaskBoard/TaskCardList/EditingTaskCard/index.js
+++ b/client/src/components/TaskBoard/TaskCardList/EditingTaskCard/index.js
@@ -1,15 +1,18 @@
 import './index.scss';
-import { makeTaskCardElement } from '../TaskCard';
-export const makeEditingTaskCardElement = (originalCardData = {}) => {
+
+export const makeEditingTaskCardElement = (
+  originalCardData = {},
+  $taskCard
+) => {
   const $editingTaskCard = document.createElement('div');
   $editingTaskCard.className = 'taskCard editing';
   $editingTaskCard.innerHTML = getInnerTemplate(originalCardData);
-  activateElement($editingTaskCard, originalCardData);
+  activateElement($editingTaskCard, $taskCard);
   return $editingTaskCard;
 };
 
 const getInnerTemplate = (originalCardData = {}) => {
-  const { title, details, author } = originalCardData;
+  const { title, details } = originalCardData;
   return `
       <input type = "text" class="taskCard__title editing" placeholder="제목을 입력하세요" value=${
         title ? title : ''
@@ -27,15 +30,14 @@ const getEditingTaskDetailTemplate = (details) => {
   return `<textarea placeholder="내용을 입력하세요" class="taskCard__detail--editing">${originalDetailContent}</textarea>`;
 };
 
-const activateElement = ($editingTaskCard, originalCardData) => {
+const activateElement = ($editingTaskCard, $taskCard) => {
   const $cancelBtn = $editingTaskCard.querySelector('.util__btn--cancel');
   $cancelBtn.addEventListener(
     'click',
-    cancelEdit.bind(null, $editingTaskCard, originalCardData)
+    cancelEdit.bind(null, $editingTaskCard, $taskCard)
   );
 };
 
-const cancelEdit = ($editingTaskCard, originalCardData) => {
-  const $taskCardElement = makeTaskCardElement(originalCardData);
-  $editingTaskCard.parentNode.replaceChild($taskCardElement, $editingTaskCard);
+const cancelEdit = ($editingTaskCard, $taskCard) => {
+  $editingTaskCard.parentNode.replaceChild($taskCard, $editingTaskCard);
 };

--- a/client/src/components/TaskBoard/TaskCardList/EditingTaskCard/index.js
+++ b/client/src/components/TaskBoard/TaskCardList/EditingTaskCard/index.js
@@ -1,15 +1,15 @@
 import './index.scss';
-
+import { makeTaskCardElement } from '../TaskCard';
 export const makeEditingTaskCardElement = (originalCardData = {}) => {
   const $editingTaskCard = document.createElement('div');
   $editingTaskCard.className = 'taskCard editing';
   $editingTaskCard.innerHTML = getInnerTemplate(originalCardData);
-  activateElement($editingTaskCard);
+  activateElement($editingTaskCard, originalCardData);
   return $editingTaskCard;
 };
 
 const getInnerTemplate = (originalCardData = {}) => {
-  const { title, details } = originalCardData;
+  const { title, details, author } = originalCardData;
   return `
       <input type = "text" class="taskCard__title editing" placeholder="제목을 입력하세요" value=${
         title ? title : ''
@@ -27,11 +27,15 @@ const getEditingTaskDetailTemplate = (details) => {
   return `<textarea placeholder="내용을 입력하세요" class="taskCard__detail--editing">${originalDetailContent}</textarea>`;
 };
 
-const activateElement = ($editingTaskCard) => {
+const activateElement = ($editingTaskCard, originalCardData) => {
   const $cancelBtn = $editingTaskCard.querySelector('.util__btn--cancel');
-  $cancelBtn.addEventListener('click', cancelEdit.bind(null, $editingTaskCard));
+  $cancelBtn.addEventListener(
+    'click',
+    cancelEdit.bind(null, $editingTaskCard, originalCardData)
+  );
 };
 
-const cancelEdit = ($editingTaskCard) => {
-  $editingTaskCard.remove();
+const cancelEdit = ($editingTaskCard, originalCardData) => {
+  const $taskCardElement = makeTaskCardElement(originalCardData);
+  $editingTaskCard.parentNode.replaceChild($taskCardElement, $editingTaskCard);
 };

--- a/client/src/components/TaskBoard/TaskCardList/TaskCard/index.js
+++ b/client/src/components/TaskBoard/TaskCardList/TaskCard/index.js
@@ -35,6 +35,6 @@ const activateElement = ($taskCard, cardData) => {
 };
 
 const convertToEditMode = ($taskCard, cardData) => {
-  const $editingCardElement = makeEditingTaskCardElement(cardData);
+  const $editingCardElement = makeEditingTaskCardElement(cardData, $taskCard);
   $taskCard.parentNode.replaceChild($editingCardElement, $taskCard);
 };


### PR DESCRIPTION
수정중인 카드가 취소 시 삭제가 되던 부분을 살짝 고쳤습니다!

TaskCard의 index.js의 covertToEditMode와 비슷한 느낌으로 taskcard를 새로 make함수를 이용해서 만들어주고 replace하는 방식으로 간단하게 구현했습니다.