### PR TITLE
[FE] 카드 추가 시 수정 카드에서 취소를 눌렀을때 카드 정상삭제 

### DIFF
--- a/client/src/components/TaskBoard/TaskCardList/EditingTaskCard/index.js
+++ b/client/src/components/TaskBoard/TaskCardList/EditingTaskCard/index.js
@@ -2,7 +2,7 @@ import './index.scss';
 
 export const makeEditingTaskCardElement = (
   originalCardData = {},
-  $taskCard
+  $taskCard = null
 ) => {
   const $editingTaskCard = document.createElement('div');
   $editingTaskCard.className = 'taskCard editing';
@@ -39,5 +39,7 @@ const activateElement = ($editingTaskCard, $taskCard) => {
 };
 
 const cancelEdit = ($editingTaskCard, $taskCard) => {
-  $editingTaskCard.parentNode.replaceChild($taskCard, $editingTaskCard);
+  if ($taskCard)
+    $editingTaskCard.parentNode.replaceChild($taskCard, $editingTaskCard);
+  else $editingTaskCard.remove();
 };

--- a/client/src/components/TaskBoard/TaskCardList/EditingTaskCard/index.js
+++ b/client/src/components/TaskBoard/TaskCardList/EditingTaskCard/index.js
@@ -2,12 +2,12 @@ import './index.scss';
 
 export const makeEditingTaskCardElement = (
   originalCardData = {},
-  $taskCard = null
+  $originalTaskCard = null
 ) => {
   const $editingTaskCard = document.createElement('div');
   $editingTaskCard.className = 'taskCard editing';
   $editingTaskCard.innerHTML = getInnerTemplate(originalCardData);
-  activateElement($editingTaskCard, $taskCard);
+  activateElement($editingTaskCard, $originalTaskCard);
   return $editingTaskCard;
 };
 
@@ -30,16 +30,19 @@ const getEditingTaskDetailTemplate = (details) => {
   return `<textarea placeholder="내용을 입력하세요" class="taskCard__detail--editing">${originalDetailContent}</textarea>`;
 };
 
-const activateElement = ($editingTaskCard, $taskCard) => {
+const activateElement = ($editingTaskCard, $originalTaskCard) => {
   const $cancelBtn = $editingTaskCard.querySelector('.util__btn--cancel');
   $cancelBtn.addEventListener(
     'click',
-    cancelEdit.bind(null, $editingTaskCard, $taskCard)
+    cancelEdit.bind(null, $editingTaskCard, $originalTaskCard)
   );
 };
 
-const cancelEdit = ($editingTaskCard, $taskCard) => {
-  if ($taskCard)
-    $editingTaskCard.parentNode.replaceChild($taskCard, $editingTaskCard);
+const cancelEdit = ($editingTaskCard, $originalTaskCard) => {
+  if ($originalTaskCard)
+    $editingTaskCard.parentNode.replaceChild(
+      $originalTaskCard,
+      $editingTaskCard
+    );
   else $editingTaskCard.remove();
 };


### PR DESCRIPTION
전까지는 삭제만 되던 상황이였고, 제가 cancelEdit에 새로운 가 들어왔을 때 이걸 교체해주는 로직만 둬 놨었는데 만약, 가 들어오지 않았다면 새로운 카드를 만드는 과정이고 취소를 누르면 삭제가 코드를 전에 지워서 기능동작이 안 됬던 것 같습니다!

if로 $taskCard가 있는지 간단한 분기처리를 하여 존재 한다면 카드가 있는 상태에서 수정하는거라 생각하고 전에 있던 $taskCard가 교체되고, 없다면 새로 카드를 생성하던 것이기 때문에 remove를 해줬습니다.