### PR TITLE
[FE] 드래그앤드롭 기능 구현 #28

### DIFF
--- a/client/src/components/TaskBoard/TaskCardList/EditingTaskCard/index.js
+++ b/client/src/components/TaskBoard/TaskCardList/EditingTaskCard/index.js
@@ -8,7 +8,7 @@ export const makeEditingTaskCardElement = (
   $originalTaskCard = null
 ) => {
   const $editingTaskCard = document.createElement('form');
-  $editingTaskCard.className = 'taskCard editing';
+  $editingTaskCard.className = 'taskcard editing';
   $editingTaskCard.dataset.id = originalCardData?.id;
   $editingTaskCard.innerHTML = getInnerTemplate(originalCardData);
   activateElement($editingTaskCard, $originalTaskCard, type);
@@ -18,7 +18,7 @@ export const makeEditingTaskCardElement = (
 const getInnerTemplate = (originalCardData = {}) => {
   const { title, details } = originalCardData;
   return `
-      <input type = "text" name='title' class="taskCard__title editing" placeholder="제목을 입력하세요" value='${
+      <input type = "text" name='title' class="taskcard__title editing" placeholder="제목을 입력하세요" value='${
         title || ''
       }' >
       ${getEditingTaskDetailTemplate(details)}
@@ -31,15 +31,15 @@ const getInnerTemplate = (originalCardData = {}) => {
 
 const getEditingTaskDetailTemplate = (details) => {
   const originalDetailContent = details ? details.join('\n') : '';
-  return `<textarea name='details' placeholder="내용을 입력하세요" class="taskCard__detail--editing" maxlength=${MAX_TASK_DETAIL_LENGTH}>${originalDetailContent}</textarea>`;
+  return `<textarea name='details' placeholder="내용을 입력하세요" class="taskcard__detail--editing" maxlength=${MAX_TASK_DETAIL_LENGTH}>${originalDetailContent}</textarea>`;
 };
 
 const activateElement = ($editingTaskCard, $originalTaskCard, type) => {
   const $cancelBtn = $editingTaskCard.querySelector('.util__btn--cancel');
   const $submitBtn = $editingTaskCard.querySelector('.util__btn--confirm');
-  const $titleInput = $editingTaskCard.querySelector('.taskCard__title');
+  const $titleInput = $editingTaskCard.querySelector('.taskcard__title');
   const $detailsTextArea = $editingTaskCard.querySelector(
-    '.taskCard__detail--editing'
+    '.taskcard__detail--editing'
   );
 
   $cancelBtn.addEventListener(
@@ -84,13 +84,3 @@ const handleConfirmBtnClick = async (type, event) => {
   else throw new Error('invalid card type');
   event.target.dispatchEvent(new Event('changeCard', { bubbles: true }));
 };
-
-// const confirmEdit = async (event) => {
-//   const { title, details } = event.target.elements;
-//   const cardId = event.target.dataset.id;
-//   const listId = event.target.closest('.taskcard-column').dataset.id;
-//   const newTitle = title.value;
-//   const newDetails = details.value.split('\n');
-//   await request.updateCard(cardId, newTitle, newDetails, listId);
-//   event.target.dispatchEvent(new Event('changeCard', { bubbles: true }));
-// };

--- a/client/src/components/TaskBoard/TaskCardList/TaskCard/index.js
+++ b/client/src/components/TaskBoard/TaskCardList/TaskCard/index.js
@@ -1,10 +1,16 @@
 import './index.scss';
 import { makeEditingTaskCardElement } from '../EditingTaskCard';
 import { makeAlertModalElement } from '../../../Modal';
+import {
+  insertElementBefore,
+  insertElementAfter,
+  hasClassName,
+  getElementIndex,
+} from '@util/domUtil.js';
 
 export const makeTaskCardElement = (cardData) => {
   const $taskCard = document.createElement('li');
-  $taskCard.className = 'taskCard';
+  $taskCard.className = 'taskcard';
   $taskCard.dataset.id = cardData.id;
   $taskCard.innerHTML = getTaskCardInnerTemplate(cardData);
   activateElement($taskCard, cardData);
@@ -14,23 +20,23 @@ export const makeTaskCardElement = (cardData) => {
 const getTaskCardInnerTemplate = (cardData) => {
   const { title, details, author } = cardData;
   return `
-    <h3 class="taskCard__title">${title}</h3>
-    <ul class="taskCard__detail-container">
+    <h3 class="taskcard__title">${title}</h3>
+    <ul class="taskcard__detail-container">
       ${getTaskDetailTemplate(details)}
     </ul>
-    <span class="taskCard__author">author by ${author}</span>
-    <button class="util__btn util__btn--delete taskCard__delete-btn"></button>
+    <span class="taskcard__author">author by ${author}</span>
+    <button class="util__btn util__btn--delete taskcard__delete-btn"></button>
   `;
 };
 
 const getTaskDetailTemplate = (details) => {
   return details
-    .map((detail) => `<li class="taskCard__detail">${detail}</li>`)
+    .map((detail) => `<li class="taskcard__detail">${detail}</li>`)
     .join('');
 };
 
 const activateElement = ($taskCard, cardData) => {
-  const $deleteBtn = $taskCard.querySelector('.taskCard__delete-btn');
+  const $deleteBtn = $taskCard.querySelector('.taskcard__delete-btn');
   $taskCard.addEventListener(
     'dblclick',
     convertToEditMode.bind(null, $taskCard, cardData)
@@ -49,6 +55,11 @@ const activateElement = ($taskCard, cardData) => {
     'click',
     handleDeleteBtnClick.bind(null, cardData.id)
   );
+
+  $taskCard.addEventListener(
+    'mousedown',
+    startDragNDrop.bind(null, $taskCard, cardData.columnId)
+  );
 };
 
 const convertToEditMode = ($taskCard, cardData) => {
@@ -61,10 +72,225 @@ const convertToEditMode = ($taskCard, cardData) => {
 };
 
 const showDeleteWarning = ($taskCard, $deleteBtn, e) => {
-  $taskCard.classList.toggle('taskCard__delete-warn');
+  $taskCard.classList.toggle('taskcard__delete-warn');
   $deleteBtn.classList.toggle('util__btn--delete-warn');
 };
 
 const handleDeleteBtnClick = (cardId, { target }) => {
   target.parentNode.append(makeAlertModalElement(cardId));
+};
+
+const startDragNDrop = ($taskCard, columnId, e) => {
+  //원래 정보
+  const [originalCardTop, originalCardLeft] = getCardPositions($taskCard);
+  const originalColumnID = columnId;
+  const originalCardIdx = getElementIndex($taskCard);
+
+  const $shadowCard = makeShadowCardNode($taskCard);
+  const $followingCard = makeFollowingCardNode(
+    $taskCard,
+    originalCardTop,
+    originalCardLeft
+  );
+
+  //카드 내 mouse위치
+  const pointerInCardX = e.clientX - originalCardLeft;
+  const pointerInCardY = e.clientY - originalCardTop;
+
+  const mouseMoveHandler = getMouseMoveHandler(
+    pointerInCardX,
+    pointerInCardY,
+    $shadowCard,
+    $followingCard
+  );
+  const mouseUpHandler = getMouseUpHandler(
+    mouseMoveHandler,
+    $shadowCard,
+    $followingCard,
+    originalColumnID,
+    originalCardIdx
+  );
+  document.body.addEventListener('mousemove', mouseMoveHandler);
+  document.body.addEventListener('mouseup', mouseUpHandler, { once: true });
+};
+
+const getCardPositions = ($card) => {
+  const originalCardTop = $card.getBoundingClientRect().top;
+  const originalCardLeft = $card.getBoundingClientRect().left;
+  return [originalCardTop, originalCardLeft];
+};
+
+const makeShadowCardNode = ($card) => {
+  const $shadowCard = $card.cloneNode(true);
+  $shadowCard.classList.add('shadow');
+  insertElementBefore($shadowCard, $card);
+  return $shadowCard;
+};
+
+const makeFollowingCardNode = ($card, originalCardTop, originalCardLeft) => {
+  const followingCardNode = $card;
+  followingCardNode.classList.add('following');
+  moveFollowingCard($card, originalCardLeft, originalCardTop);
+  return followingCardNode;
+};
+
+const moveFollowingCard = ($card, posX, posY) => {
+  $card.style.left = posX + 'px';
+  $card.style.top = posY + 'px';
+};
+
+const getMouseMoveHandler =
+  (pointerInCardX, pointerInCardY, $shadowCard, $followingCard) => (event) => {
+    handleFollowingCard(pointerInCardX, pointerInCardY, $followingCard, event);
+    handleCardShadow($shadowCard, $followingCard, event);
+  };
+
+const getMouseUpHandler =
+  (
+    mouseMoveHandler,
+    shadowCardNode,
+    followingCardNode,
+    originalParentColumnID,
+    originalCardIdx
+  ) =>
+  () => {
+    endDragDropEvent(
+      mouseMoveHandler,
+      shadowCardNode,
+      followingCardNode,
+      originalParentColumnID,
+      originalCardIdx
+    );
+  };
+
+const handleFollowingCard = (shiftX, shiftY, $followingCard, event) => {
+  const [posX, posY] = getCardPosition(shiftX, shiftY, event);
+  moveFollowingCard($followingCard, posX, posY);
+};
+
+const getCardPosition = (shiftX, shiftY, event) => {
+  const x = event.clientX - shiftX;
+  const y = event.clientY - shiftY;
+  return [x, y];
+};
+
+const handleCardShadow = ($shadowCard, $followingCard, event) => {
+  const underMouseElement = getUnderMouseElement(
+    $followingCard,
+    event.clientX,
+    event.clientY
+  );
+  const underMouseElementClass = inspectElementClass(underMouseElement);
+  moveCardShadow(underMouseElementClass, underMouseElement, $shadowCard, event);
+};
+
+const moveCardShadow = (
+  underMouseElementClass,
+  underMouseElement,
+  shadowCardNode,
+  event
+) => {
+  switch (underMouseElementClass) {
+    case 'taskcard':
+      moveToAroundCard(underMouseElement, shadowCardNode, event);
+      return;
+    case 'card-content':
+      const parentCardElement = underMouseElement.closest('.taskcard');
+      moveToAroundCard(parentCardElement, shadowCardNode, event);
+      return;
+    case 'taskcard-list':
+      moveToColumn(underMouseElement, shadowCardNode);
+      return;
+  }
+};
+
+const moveToAroundCard = (underMouseCardElement, cardNode, event) => {
+  const rect = underMouseCardElement.getBoundingClientRect();
+  if (event.clientY < (rect.top + rect.bottom) / 2) {
+    insertElementBefore(cardNode, underMouseCardElement);
+  } else {
+    insertElementAfter(cardNode, underMouseCardElement);
+  }
+};
+
+const moveToColumn = (underMouseColumnElement, cardNode) => {
+  underMouseColumnElement.append(cardNode);
+};
+
+const getUnderMouseElement = (followingCardNode, x, y) => {
+  followingCardNode.hidden = true;
+  const underMouseElement = document.elementFromPoint(x, y);
+  followingCardNode.hidden = false;
+  return underMouseElement;
+};
+
+const inspectElementClass = (underMouseElement) => {
+  if (
+    hasClassName(underMouseElement, 'taskcard') &&
+    !hasClassName(underMouseElement, 'shadow')
+  ) {
+    return 'taskcard';
+  } else if (hasClassName(underMouseElement, 'taskcard-list')) {
+    return 'taskcard-list';
+  } else if (underMouseElement.closest('.taskcard')) {
+    return 'card-content';
+  } else {
+    return 'others';
+  }
+};
+
+const endDragDropEvent = (
+  mouseMoveHandler,
+  shadowCardNode,
+  followingCardNode,
+  originalParentColumnID,
+  originalCardIdx
+) => {
+  document.body.removeEventListener('mousemove', mouseMoveHandler);
+  putFollowingCardOnShadow(followingCardNode, shadowCardNode);
+  disconnectFollowingCard(followingCardNode);
+  shadowCardNode.remove();
+  updateResult(followingCardNode, originalParentColumnID, originalCardIdx);
+};
+
+const putFollowingCardOnShadow = (followingCardNode, shadowCardNode) => {
+  insertElementBefore(followingCardNode, shadowCardNode);
+};
+
+const disconnectFollowingCard = (followingCardNode) => {
+  followingCardNode.classList.remove('following');
+  followingCardNode.style.left = 0;
+  followingCardNode.style.top = 0;
+};
+
+const updateResult = (
+  followingCardNode,
+  originalParentColumnID,
+  originalCardIdx
+) => {
+  const newParentColumnID = Number(
+    followingCardNode.closest('.taskcard-column').dataset.id
+  );
+  const cardID = followingCardNode.dataset.id;
+  const movedIdx = getElementIndex(followingCardNode);
+  if (
+    isCardPositionChanged(
+      originalParentColumnID,
+      newParentColumnID,
+      originalCardIdx,
+      movedIdx
+    )
+  )
+    console.log('changed!');
+};
+
+const isCardPositionChanged = (
+  originalParentColumnID,
+  newParentColumnID,
+  originalCardIdx,
+  movedIdx
+) => {
+  return (
+    originalParentColumnID !== newParentColumnID || originalCardIdx !== movedIdx
+  );
 };

--- a/client/src/components/TaskBoard/TaskCardList/TaskCard/index.js
+++ b/client/src/components/TaskBoard/TaskCardList/TaskCard/index.js
@@ -7,6 +7,8 @@ import {
   hasClassName,
   getElementIndex,
 } from '@util/domUtil.js';
+import Point from '@util/Point';
+import { getElementPos } from '../../../../util/domUtil';
 
 export const makeTaskCardElement = (cardData) => {
   const $taskCard = document.createElement('li');
@@ -58,7 +60,7 @@ const activateElement = ($taskCard, cardData) => {
 
   $taskCard.addEventListener(
     'mousedown',
-    startDragNDrop.bind(null, $taskCard, cardData.columnId)
+    handleMouseDownEvent.bind(null, $taskCard, cardData.columnId)
   );
 };
 
@@ -80,18 +82,31 @@ const handleDeleteBtnClick = (cardId, { target }) => {
   target.parentNode.append(makeAlertModalElement(cardId));
 };
 
-const startDragNDrop = ($taskCard, columnId, e) => {
-  //원래 정보
-  const [originalCardTop, originalCardLeft] = getCardPositions($taskCard);
-  const originalColumnID = columnId;
-  const originalCardIdx = getElementIndex($taskCard);
+////////////////
+////////////////
+////////////////
+////////////////
+////////////////
+////////////////
+////////////////
+////////////////
+////////////////
+////////////////
+////////////////
+////////////////
 
-  const $shadowCard = makeShadowCardNode($taskCard);
-  const $followingCard = makeFollowingCardNode(
-    $taskCard,
-    originalCardTop,
-    originalCardLeft
-  );
+const handleMouseDownEvent = ($taskCard, columnId, e) => {
+  if (e.detail !== 1) return;
+  startDragNDrop($taskCard, columnId, e);
+};
+
+const startDragNDrop = ($taskCard, columnId, e) => {
+  const originalCardPoint = getOriginalCardPoint($taskCard);
+  const originalCardIdx = getElementIndex($taskCard);
+  const originalColumnID = columnId;
+
+  const $shadowCard = makeShadowCardElement($taskCard);
+  const $followingCard = makeFollowingCardElement($taskCard, originalCardPoint);
 
   //카드 내 mouse위치
   const pointerInCardX = e.clientX - originalCardLeft;
@@ -114,20 +129,19 @@ const startDragNDrop = ($taskCard, columnId, e) => {
   document.body.addEventListener('mouseup', mouseUpHandler, { once: true });
 };
 
-const getCardPositions = ($card) => {
-  const originalCardTop = $card.getBoundingClientRect().top;
-  const originalCardLeft = $card.getBoundingClientRect().left;
-  return [originalCardTop, originalCardLeft];
+const getOriginalCardPoint = ($taskCard) => {
+  const [originalCardX, originalCardY] = getElementPos($taskCard);
+  return new Point(originalCardX, originalCardY);
 };
 
-const makeShadowCardNode = ($card) => {
+const makeShadowCardElement = ($card) => {
   const $shadowCard = $card.cloneNode(true);
   $shadowCard.classList.add('shadow');
   insertElementBefore($shadowCard, $card);
   return $shadowCard;
 };
 
-const makeFollowingCardNode = ($card, originalCardTop, originalCardLeft) => {
+const makeFollowingCardElement = ($card, originalCardTop, originalCardLeft) => {
   const followingCardNode = $card;
   followingCardNode.classList.add('following');
   moveFollowingCard($card, originalCardLeft, originalCardTop);

--- a/client/src/components/TaskBoard/TaskCardList/TaskCard/index.scss
+++ b/client/src/components/TaskBoard/TaskCardList/TaskCard/index.scss
@@ -5,9 +5,7 @@
   padding: 1rem;
   background-color: $white;
   border-radius: 0.375rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+  width: 19.25rem;
 
   &__title {
     font-weight: $bold;
@@ -41,4 +39,5 @@
 
 .following {
   position: fixed;
+  z-index: 100;
 }

--- a/client/src/components/TaskBoard/TaskCardList/TaskCard/index.scss
+++ b/client/src/components/TaskBoard/TaskCardList/TaskCard/index.scss
@@ -1,6 +1,6 @@
 @import '@style/variable.scss';
 
-.taskCard {
+.taskcard {
   position: relative;
   padding: 1rem;
   background-color: $white;
@@ -32,4 +32,13 @@
     background-color: rgba($red, 0.5);
     border: 1px red solid;
   }
+}
+
+.shadow {
+  opacity: 0.2;
+  box-shadow: 0 0 0 1px $blue inset;
+}
+
+.following {
+  position: fixed;
 }

--- a/client/src/components/TaskBoard/TaskCardList/index.scss
+++ b/client/src/components/TaskBoard/TaskCardList/index.scss
@@ -6,6 +6,7 @@
     display: flex;
     flex-direction: column;
     gap: 1rem;
+    height: 100%;
   }
 
   &-column {

--- a/client/src/components/TaskBoard/index.scss
+++ b/client/src/components/TaskBoard/index.scss
@@ -1,4 +1,5 @@
 .task-board {
   display: flex;
   gap: 1rem;
+  flex-grow: 1;
 }

--- a/client/src/index.scss
+++ b/client/src/index.scss
@@ -6,6 +6,12 @@ body {
   padding: 0rem 5rem;
 }
 
+#app {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
 .util {
   &__btns {
     display: flex;

--- a/client/src/mocks/handlers.js
+++ b/client/src/mocks/handlers.js
@@ -77,11 +77,27 @@ const deleteCardData = (req, res, ctx) => {
   );
 };
 
+const moveCard = (req, res, ctx) => {
+  const { id: cardId } = req.params;
+  const { originalColumnId, newColumnId, originalIdx, newIdx } = req.body;
+  taskTable[cardId].columnId = newColumnId;
+  taskColumnTable[originalColumnId].taskIds.splice(originalIdx, 1);
+  taskColumnTable[newColumnId].taskIds.splice(newIdx, 0, +cardId);
+  return res(
+    ctx.status(200),
+    ctx.json({
+      status: 'OK',
+      message: '정상 이동되었습니다',
+    })
+  );
+};
+
 const handlers = [
   rest.get('/api/taskcolumns', getAllTaskColumn),
   rest.get('/api/taskcolumn/:id', getTaskColumn),
   rest.post('/api/taskcard', addNewCard),
   rest.patch('/api/taskcard/:id', updateCardData),
+  rest.patch('/api/taskcard/:id/move', moveCard),
   rest.delete('/api/taskcard/:id', deleteCardData),
 ];
 export default handlers;

--- a/client/src/util/Point.js
+++ b/client/src/util/Point.js
@@ -1,0 +1,14 @@
+export default class Point {
+  constructor(x, y) {
+    this.x = x;
+    this.y = y;
+  }
+
+  get() {
+    return [this.x, this.y];
+  }
+
+  diff(point) {
+    return [this.x - point.x, this.y - point.y];
+  }
+}

--- a/client/src/util/domUtil.js
+++ b/client/src/util/domUtil.js
@@ -1,20 +1,19 @@
-export const insertNodeBefore = (targetNode, referenceNode) => {
-  referenceNode.parentNode.insertBefore(targetNode, referenceNode);
+export const insertElementBefore = (targetElement, referenceElement) => {
+  referenceElement.parentElement.insertBefore(targetElement, referenceElement);
 };
 
-export const insertNodeAfter = (targetNode, referenceNode) => {
-  referenceNode.parentNode.insertBefore(targetNode, referenceNode.nextSibling);
-};
-
-export const removeNodeself = (node) => {
-  node.parentNode.removeChild(node);
+export const insertElementAfter = (targetElement, referenceElement) => {
+  referenceElement.parentNode.insertBefore(
+    targetElement,
+    referenceElement.nextSibling
+  );
 };
 
 export const hasClassName = (element, className) => {
   return element.classList.contains(className);
 };
 
-export const getNodeIndex = (node) => {
+export const getElementIndex = (node) => {
   let idx = 0;
   while (node.previousSibling) {
     idx++;

--- a/client/src/util/domUtil.js
+++ b/client/src/util/domUtil.js
@@ -21,3 +21,9 @@ export const getElementIndex = (node) => {
   }
   return idx;
 };
+
+export const getElementPos = ($) => {
+  const y = $.getBoundingClientRect().top;
+  const x = $.getBoundingClientRect().left;
+  return [x, y];
+};

--- a/client/src/util/domUtil.js
+++ b/client/src/util/domUtil.js
@@ -1,0 +1,24 @@
+export const insertNodeBefore = (targetNode, referenceNode) => {
+  referenceNode.parentNode.insertBefore(targetNode, referenceNode);
+};
+
+export const insertNodeAfter = (targetNode, referenceNode) => {
+  referenceNode.parentNode.insertBefore(targetNode, referenceNode.nextSibling);
+};
+
+export const removeNodeself = (node) => {
+  node.parentNode.removeChild(node);
+};
+
+export const hasClassName = (element, className) => {
+  return element.classList.contains(className);
+};
+
+export const getNodeIndex = (node) => {
+  let idx = 0;
+  while (node.previousSibling) {
+    idx++;
+    node = node.previousSibling;
+  }
+  return idx;
+};

--- a/client/src/util/fetchUtil.js
+++ b/client/src/util/fetchUtil.js
@@ -11,10 +11,10 @@ const request = {
 
   async deleteCard(cardId) {
     const requestMessage = makeRequestMessage('DELETE');
-    const changedList = await (
+    const res = await (
       await fetch(`/api/taskcard/${cardId}`, requestMessage)
     ).json();
-    return changedList;
+    return res;
   },
 
   async updateCard(cardId, title, details) {
@@ -22,10 +22,10 @@ const request = {
       title,
       details,
     });
-    const changedList = await (
+    const res = await (
       await fetch(`/api/taskcard/${cardId}`, requestMessage)
     ).json();
-    return changedList;
+    return res;
   },
 
   async addCard(columnId, title, details) {
@@ -34,10 +34,21 @@ const request = {
       title,
       details,
     });
-    const updatedColumnState = await (
-      await fetch(`/api/taskcard`, requestMessage)
+    const res = await (await fetch(`/api/taskcard`, requestMessage)).json();
+    return res;
+  },
+
+  async moveCard(cardId, originalColumnId, newColumnId, originalIdx, newIdx) {
+    const requestMessage = makeRequestMessage('PATCH', {
+      originalColumnId,
+      newColumnId,
+      originalIdx,
+      newIdx,
+    });
+    const res = await (
+      await fetch(`/api/taskcard/${cardId}/move`, requestMessage)
     ).json();
-    return updatedColumnState;
+    return res;
   },
 };
 


### PR DESCRIPTION
드래그앤드롭을 구현했습니다.
마우스 다운시 이벤트가 트리거되면, mousemove, mouseup이벤트를 달아줍니다.

mousemove는 따라다니는 카드를 handle하고 마우스 움직임에 따라 카드 그림자를 handle합니다.
moueup은 한번만 수행후 이벤트가 제거되며, 드래그 이벤트를 종료시키고 서버에 업데이트하는 역하을 합니다. 
이때 mousemove이벤트도 제거해줍니다.

로직을 구현하다보니 삭제 이벤트가 잘안되게 되거나, css가 살짝 어긋나진 부분이 있습니다. 
이후 이슈에서 수정하도록 하겠습니다